### PR TITLE
Allow the theme to override regular_price before setting the subtotal

### DIFF
--- a/sale-discount-for-woocommerce.php
+++ b/sale-discount-for-woocommerce.php
@@ -159,6 +159,8 @@ class WPO_WC_SPAD {
 					'price' => $product->get_regular_price(),
 				] );
 
+				$regular_price = apply_filters('wpo_wc_sale_discount_regular_price', $regular_price, $item, $order);
+
 				// set regular price as before-discount item price
 				$item->set_subtotal( $regular_price );
 


### PR DESCRIPTION
This adds a filter just before setting the item subtotal, so the theme or other plugins can modify the price used for the subtotal.